### PR TITLE
Add CheckboxGroupField as a component option

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ formik-antd components props expose the `name: string` and `validate: (value: an
 | Name               | Props                                                                                                      |
 | ------------------ | ---------------------------------------------------------------------------------------------------------- |
 | CheckboxField      | { name, validate } & [Checkbox](https://ant.design/components/checkbox/)                                   |
+| CheckboxGroupField | { name, validate } & [CheckboxGroup](https://ant.design/components/checkbox/#Checkbox-Group)               |
 | DatePickerField    | { name, validate } & [DatePicker](https://ant.design/components/date-picker/)                              |
 | InputField         | { name, validate } & [Input](https://ant.design/components/input/)                                         |
 | InputNumberField   | { name, validate } & [InputNumber](https://ant.design/components/input-number/)                            |

--- a/src/CheckboxGroupField.tsx
+++ b/src/CheckboxGroupField.tsx
@@ -1,0 +1,19 @@
+import { Checkbox } from "antd";
+import { Field, FieldProps } from "formik";
+import * as React from "react";
+import { CheckboxGroupProps } from "antd/lib/checkbox/Group";
+import { FormikFieldProps } from "./FieldProps";
+
+export const CheckboxGroupField = (
+  { name, validate, ...restProps }: FormikFieldProps & CheckboxGroupProps 
+) => (
+  <Field name={name} validate={validate}>
+    {({ field: { name: fieldName, value: fieldValue }, form: { setFieldValue } }: FieldProps) => (
+      <Checkbox.Group
+        value={fieldValue}
+        onChange={value => setFieldValue( fieldName, value )}
+        {...restProps}
+      />
+    )}
+  </Field>
+);

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,3 +16,4 @@ export * from "./SubmitButton";
 export * from "./ResetButton";
 export * from "./HtmlTextField";
 export * from "./CheckboxField";
+export * from "./CheckboxGroupField";


### PR DESCRIPTION
Pretty simply adds a CheckboxGroup component.
Instead of passing a dataSource, you'd pass options.

```
          <CheckboxGroupField 
            name="checkboxGroup"
            options={[
              { label: "Foo", value: "foo" },
              { label: <span>Bar</span>, value: "bar" }
            ]}
          />
```