### PR TITLE
Simplify RadioGroupField according to AntDesign specs

### DIFF
--- a/src/RadioGroupField.tsx
+++ b/src/RadioGroupField.tsx
@@ -8,7 +8,7 @@ export const RadioGroupField = (
   { name, validate, ...restProps }: FormikFieldProps & RadioGroupProps
 ) => (
   <Field name={name} validate={validate}>
-    {({ field: { name, value }, form: { setFieldValue } }: FieldProps) => (
+    {({ field: { value }, form: { setFieldValue } }: FieldProps) => (
       <Radio.Group 
         value={value}
         onChange={e => setFieldValue(name, e.target.value)}

--- a/src/RadioGroupField.tsx
+++ b/src/RadioGroupField.tsx
@@ -4,32 +4,16 @@ import * as React from "react";
 import { RadioGroupProps } from "antd/lib/radio/interface";
 import { FormikFieldProps, IDataSourceObject } from "./FieldProps";
 
-export const RadioGroupField = ({
-  name,
-  validate,
-  dataSource,
-  children,
-  ...restProps
-}: FormikFieldProps &
-  RadioGroupProps & {
-    dataSource?: Array<IDataSourceObject>;
-    children?: React.ReactNode;
-  }) => (
+export const RadioGroupField = (
+  { name, validate, ...restProps }: FormikFieldProps & RadioGroupProps
+) => (
   <Field name={name} validate={validate}>
-    {({ field, form }: FieldProps) => (
-      <Radio.Group {...restProps}>
-        {Array.isArray(dataSource) &&
-          dataSource.map(({ value, label }: IDataSourceObject) => (
-            <Radio
-              key={`radio-${value}`}
-              value={value}
-              onChange={e => form.setFieldValue(name, e.target.value)}
-            >
-              {label}
-            </Radio>
-          ))}
-        {children}
-      </Radio.Group>
+    {({ field: { name, value }, form: { setFieldValue } }: FieldProps) => (
+      <Radio.Group 
+        value={value}
+        onChange={e => setFieldValue(name, e.target.value)}
+        {...restProps}
+      />
     )}
   </Field>
 );


### PR DESCRIPTION
Just like #11 this component actually uses the `options` prop as part of Ant Design to generate the list of radio buttons.
https://ant.design/components/radio/#RadioGroup

This greatly simplifies this component

Usage:
```
          <RadioGroupField
            name="radioGroup"
            options={[
              { label: "Foo", value: "foo" },
              { label: <span>Bar</span>, value: "bar" }
            ]}
          />
```