### PR TITLE
Remove unnecessary field name destructuring for components

### DIFF
--- a/src/CheckboxField.tsx
+++ b/src/CheckboxField.tsx
@@ -8,7 +8,7 @@ export const CheckboxField = (
   { name, validate, ...restProps }: FormikFieldProps & CheckboxProps
 ) => (
   <Field name={name} validate={validate}>
-    {({ field: { name, value, onChange } }: FieldProps) => (
+    {({ field: { value, onChange } }: FieldProps) => (
       <Checkbox name={name} checked={value} onChange={onChange} {...restProps} />
     )}
   </Field>

--- a/src/SwitchField.tsx
+++ b/src/SwitchField.tsx
@@ -8,7 +8,7 @@ export const SwitchField = (
   { name, validate, ...restProps }: FormikFieldProps & SwitchProps
 ) => (
   <Field name={name} validate={validate}>
-    {({ field: { name, value }, form: { setFieldValue } }: FieldProps) => (
+    {({ field: { value }, form: { setFieldValue } }: FieldProps) => (
       <Switch
         checked={value}
         onChange={v => setFieldValue(name, v)}

--- a/src/TextAreaField.tsx
+++ b/src/TextAreaField.tsx
@@ -8,7 +8,7 @@ export const TextAreaField = (
   { name, validate, ...restProps }: FormikFieldProps & TextAreaProps
 ) => (
   <Field name={name} validate={validate}>
-    {({ field: { name, value, onChange, onBlur } }: FieldProps) => (
+    {({ field: { value, onChange, onBlur } }: FieldProps) => (
       <Input.TextArea
         name={name}
         value={value}


### PR DESCRIPTION
In order to be consistent through all components, I've removed some name destructuring that I've overlooked