### PR TITLE
Tracking branch for 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,13 @@
 
 [CodeSandbox](https://codesandbox.io/s/oko82yzn6)
 
+## Version 1.0.0
+
+Upcoming is version 1.0.0.
+
+Breaking changes:
+ - the validate function will be removed
+
 # formik-antd
 
 Simple declarative bindings for [Ant Design](https://ant.design/docs/react/introduce) and [Formik](https://github.com/jaredpalmer/formik).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@jbuschke/formik-antd",
-  "version": "0.14.0",
+  "version": "1.0.0-preview.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jbuschke/formik-antd",
-  "version": "0.14.0",
+  "version": "1.0.0-preview.0",
   "author": "Jannik Buschke",
   "description": "Declarative bindings for formik and ant design.",
   "displayName": "formik-antd",

--- a/src/Form.tsx
+++ b/src/Form.tsx
@@ -1,0 +1,13 @@
+import * as React from "react";
+
+import { Field, FieldProps } from "formik";
+import { Form as AntdForm } from "antd";
+import { FormProps } from "antd/lib/form";
+
+export function Form(props: FormProps) {
+  return <Field>
+    {({ form: { handleReset, handleSubmit } }: FieldProps) => (
+      <AntdForm onReset={handleReset} onSubmit={handleSubmit} {...props} />
+    )}
+  </Field>
+}

--- a/src/SubmitButton.tsx
+++ b/src/SubmitButton.tsx
@@ -3,26 +3,12 @@ import { Field, FieldProps } from "formik";
 import * as React from "react";
 import { ButtonProps } from "antd/lib/button";
 
-export const SubmitButton = ({
-  children,
-  onSuccess,
-  ...restProps
-}: ButtonProps & { onSuccess?: () => void }) => (
+export const SubmitButton = ({ children, onSuccess, ...restProps }: ButtonProps & { onSuccess?: () => void }) => (
   <Field>
-    {({
-      form: { handleSubmit, isSubmitting, isValid, setSubmitting }
-    }: FieldProps) => (
+    {({ form: { isSubmitting, isValid } }: FieldProps) => (
       <Button
-        onClick={async () => {
-          setSubmitting(true);
-          await handleSubmit();
-          setSubmitting(false);
-          if (onSuccess) {
-            onSuccess();
-          }
-        }}
         loading={isSubmitting}
-        disabled={!isValid}
+        disabled={!isValid || isSubmitting}
         type="primary"
         htmlType="submit"
         {...restProps}

--- a/src/TreeSelect.tsx
+++ b/src/TreeSelect.tsx
@@ -1,0 +1,22 @@
+import { TreeSelect as $TreeSelect } from "antd";
+import { Field, FieldProps } from "formik";
+import * as React from "react";
+import { FormikFieldProps } from "./FieldProps";
+import { TreeSelectProps } from "antd/lib/tree-select";
+
+export const TreeSelect = ({
+  name,
+  validate,
+  ...restProps
+}: FormikFieldProps & TreeSelectProps & { children: React.ReactNode }) => (
+    <Field name={name} validate={validate}>
+      {({ field: { value }, form }: FieldProps) => (
+        <$TreeSelect
+          value={value}
+          onChange={e => form.setFieldValue(name, e.valueOf())}
+          onBlur={e => form.setFieldTouched(name)}
+          {...restProps}
+        />
+      )}
+    </Field>
+  );

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,3 +17,4 @@ export * from "./Rate";
 export * from "./Slider";
 export * from "./Cascader";
 export * from "./AutoComplete";
+export * from "./Form";

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,3 +18,4 @@ export * from "./Slider";
 export * from "./Cascader";
 export * from "./AutoComplete";
 export * from "./Form";
+export * from "./TreeSelect";


### PR DESCRIPTION
A PR to track the remaining work for a 1.0 release

- [x] Add Cascader
- [x] Add AutoComplete
- [x] Add TreeSelect
- [x] Add Mention
- [x] Find solution/recommendation whether to use `<form>` and native button type attributes
- [x] Add Form component
- [x] Remove onClickHandler from SubmitButton (triggers now native html form submission)
- [x] Create a pre-release
- [x] Document breaking changes
- [x] Update sample to use `<Form>`
- [x] Remove all `validate` props
- [x] Remove Action
- [x] Remove IDataSourceObject
- [x] Add Transfer
- [x] Update documentation
- [x] Reenable field validation