### PR TITLE
Add validate prop to Form.Item (closes #71)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,13 @@ To learn about Antd components just visit the official docs. Most supported comp
 Formik provides form- and field-level [validation callbacks](https://jaredpalmer.com/formik/docs/guides/validation) to provide validation logic. How to validate is neither part of formik nor of this library.
 
 Form-level validation is done by setting formiks `validate` prop. Field-level validation is optional available on the components. Additional to the `name` prop formiks optional `validate?: (value: any) => undefined | string | Promise<any>` is added to all core components to allow field-level validation.
+There is one special case to be aware of when using field-level validation: When using the `Form.Item` component with another Antd-field component, the `validate` prop has to be added to the `Form.Item`, not the input component:
+
+```jsx
+<Form.Item name="firstName" validate={validator}>
+  <Input name="firstName" />
+</Form.Item>
+```
 
 ## Rendering Validation Feedback
 

--- a/src/form-item/index.test.tsx
+++ b/src/form-item/index.test.tsx
@@ -61,3 +61,44 @@ test("handles changes on multiselect without prop-types error", async () => {
   //@ts-ignore
   console.error.mockRestore();
 });
+
+test("displays validation result on nested input", async () => {
+  const validate = () => "error";
+  const { getByTestId, queryByText } = render(
+    <Formik initialValues={{}} onSubmit={() => {}}>
+      <Form>
+        <FormItem name="test" validate={validate}>
+          <Input name="test" data-testid="input" />
+        </FormItem>
+        <SubmitButton data-testid="submit" />
+      </Form>
+    </Formik>
+  );
+  expect(queryByText("error")).not.toBeInTheDocument();
+  fireEvent.change(getByTestId("input"), {
+    target: { name: "test", value: "test" }
+  });
+  fireEvent.blur(getByTestId("input"));
+  fireEvent.click(getByTestId("submit"));
+  await waitForDomChange();
+  expect(queryByText("error")).toBeInTheDocument();
+});
+
+test("displays validation success ", async () => {
+  const validate = () => undefined;
+  const { getByTestId, queryByLabelText } = render(
+    <Formik initialValues={{}} onSubmit={() => {}}>
+      <Form>
+        <FormItem name="test" validate={validate} showValidateSuccess>
+          <Input name="test" data-testid="input" />
+        </FormItem>
+      </Form>
+    </Formik>
+  );
+  expect(queryByLabelText("icon: check-circle")).not.toBeInTheDocument();
+  fireEvent.change(getByTestId("input"), {
+    target: { name: "test", value: "test" }
+  });
+  fireEvent.blur(getByTestId("input"));
+  expect(queryByLabelText("icon: check-circle")).toBeInTheDocument();
+});

--- a/src/form-item/index.tsx
+++ b/src/form-item/index.tsx
@@ -1,19 +1,21 @@
 import * as React from "react";
-import { Field, FieldProps, getIn } from "formik";
+import { Field, FieldProps, getIn, FieldConfig } from "formik";
 import { Form } from "antd";
 import { FormItemProps as $FormItemProps } from "antd/lib/form/FormItem";
 export type FormItemProps = {
   showValidateSuccess?: boolean;
   children: React.ReactNode;
-} & { name: string } & $FormItemProps;
+} & { name: string } & $FormItemProps &
+  Pick<FieldConfig, "validate">;
 
 export const FormItem = ({
   name,
   showValidateSuccess,
   children,
+  validate,
   ...restProps
 }: FormItemProps) => (
-  <Field name={name}>
+  <Field name={name} validate={validate}>
     {({ form: { errors = {}, touched = {} } }: FieldProps) => {
       const error = getIn(errors, name, undefined);
       let isTouched = getIn(touched, name, false) as boolean | boolean[];


### PR DESCRIPTION
This is an attempt to fix #71.
The problem there is that both `Form.Item` and `Input` create a formik-`Field` with the same name. Validation is only executed on the outer `Field`.
I assume the reason it works with an inline `validate`-callback is that this forces the inner `Field` to be rerendered, which I assume executed the validation during render? I'm not entirely sure.
In order to fix this problem the abilty to add a  `validate`-callback to `Form.Item` has been added. See the changed Readme for usage.