### PR TITLE
Handle null and undefined value for AutoComplete, Rate and Slider

### DIFF
--- a/src/auto-complete/index.tsx
+++ b/src/auto-complete/index.tsx
@@ -12,7 +12,7 @@ export const AutoComplete = ({ name, validate, onChange, onBlur, ...restProps }:
       <$AutoComplete
         value={value}
         onChange={value => {
-          form.setFieldValue(name, value.valueOf())
+          form.setFieldValue(name, value != null ? value.valueOf() : value)
           onChange && onChange(value)
         }}
         onBlur={value => {

--- a/src/rate/index.tsx
+++ b/src/rate/index.tsx
@@ -12,7 +12,7 @@ export const Rate = ({ name, validate, onChange, ...restProps }: RateProps) => (
       <$Rate
         value={value}
         onChange={value => {
-          setFieldValue(name, value.valueOf())
+          setFieldValue(name, value != null ? value.valueOf() : value)
           setFieldTouched(name, true)
           onChange && onChange(value)
         }}

--- a/src/slider/index.tsx
+++ b/src/slider/index.tsx
@@ -12,7 +12,7 @@ export const Slider = ({ name, validate, onChange, ...restProps }: SliderProps) 
       <$Slider
         value={value}
         onChange={value => {
-          setFieldValue(name, value.valueOf())
+          setFieldValue(name, value != null ? value.valueOf() : value)
           setFieldTouched(name, true)
           onChange && onChange(value)
         }}


### PR DESCRIPTION
This allows `AutoComplete` component to support `allowClear` option. 
As of now, `AutoComplete` doesn't change value on clear button click. Also, an error in browser console is shown.
```
Uncaught TypeError: Cannot read property 'valueOf' of undefined
```

Here is a small demo that demonstrates this issue:
https://codesandbox.io/s/formikantd-autocomplete-allowclear-rwnkt