### PR TITLE
Fix FormItem throws error when isTouched is empty array

### DIFF
--- a/src/form-item/index.tsx
+++ b/src/form-item/index.tsx
@@ -20,7 +20,7 @@ export const FormItem = ({
       const error = getIn(errors, name, undefined);
       let isTouched = getIn(touched, name, false) as boolean | boolean[];
       if (Array.isArray(isTouched)) {
-        isTouched = isTouched.reduce((acc, value) => acc || value);
+        isTouched = isTouched.reduce((acc, value) => acc || value, false);
       }
       const hasError = error !== undefined && isTouched;
       const isValid = !error && isTouched;


### PR DESCRIPTION
This fixes app crash caused by the following error in `FormItem`:
```
TypeError: Reduce of empty array with no initial value
```

This issue occurs if we have dynamic array and it can be empty.
Demo: https://codesandbox.io/s/formikantd-formitem-istouched-array-0gou5