### PR TITLE
Prevent production build from removing styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
     "design",
     "form"
   ],
-  "sideEffects": false,
+  "sideEffects": [
+    "es/**/style/*",
+    "lib/**/style/*"
+  ],
   "license": "MIT",
   "private": false,
   "files": [


### PR DESCRIPTION
In `package.json` property `sideEffects` is set to false, which causes tree shaking for any imported file that has no used tokens. This is usually desired for JS modules, but for CSS files side effects are intended.

Marking style directories as having side effects prevents those files from being removed during production builds. This is accomplished by updating `package.json` to:

```json
{
  "sideEffects": [
    "es/**/style/*",
    "lib/**/style/*"
  ]
}
```


This fixes the style problem discussed in #63 and #92.