### PR TITLE
Added support for initialErrors in FormItem

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "watch": "tsc --watch",
     "cleanbuild": "rm -r node_modules && npm install && tsc",
     "test": "jest",
-    "watch-test":"jest --watch"
+    "watch-test": "jest --watch"
   },
   "dependencies": {},
   "peerDependencies": {

--- a/src/form-item/index.test.tsx
+++ b/src/form-item/index.test.tsx
@@ -42,6 +42,84 @@ test("displays validation result", async () => {
   expect(queryByText("error")).toBeInTheDocument();
 });
 
+test("displayes initial error", async () => {
+  const { queryByText } = render(
+    <Formik
+      initialErrors={{ test: "initialError" }}
+      initialValues={{}}
+      onSubmit={() => {}}
+    >
+      <Form>
+        <FormItem name="test">
+          <Input name="test" data-testid="input" />
+        </FormItem>
+      </Form>
+    </Formik>
+  );
+  expect(queryByText("initialError")).toBeInTheDocument();
+});
+
+test("displayes error instead of initialError after touched when showInitialErrorAfterTouched is false", async () => {
+  const validate = () => "error";
+  const { getByTestId, queryByText } = render(
+    <Formik
+      initialErrors={{ test: "initialError" }}
+      initialValues={{}}
+      showInitialErrorAfterTouched={false}
+      onSubmit={() => {}}
+    >
+      <Form>
+        <FormItem name="test" validate={validate}>
+          <Input name="test" data-testid="input" />
+        </FormItem>
+        <SubmitButton data-testid="submit" />
+      </Form>
+    </Formik>
+  );
+  expect(queryByText("initialError")).toBeInTheDocument();
+  expect(queryByText("error")).not.toBeInTheDocument();
+  fireEvent.change(getByTestId("input"), {
+    target: { name: "test", value: "test" }
+  });
+  fireEvent.blur(getByTestId("input"));
+  fireEvent.click(getByTestId("submit"));
+  await waitForDomChange();
+  expect(queryByText("error")).toBeInTheDocument();
+  expect(queryByText("initialError")).not.toBeInTheDocument();
+});
+
+test("displayes initialError with error after touched when showInitialErrorAfterTouched is true", async () => {
+  const validate = () => "error";
+  const { getByTestId, queryByText } = render(
+    <Formik
+      initialErrors={{ test: "initialError" }}
+      initialValues={{}}
+      onSubmit={() => {}}
+    >
+      <Form>
+        <FormItem
+          name="test"
+          validate={validate}
+          showInitialErrorAfterTouched={true}
+        >
+          <Input name="test" data-testid="input" />
+        </FormItem>
+        <SubmitButton data-testid="submit" />
+      </Form>
+    </Formik>
+  );
+  expect(queryByText("initialError")).toBeInTheDocument();
+  expect(queryByText("error")).not.toBeInTheDocument();
+  fireEvent.change(getByTestId("input"), {
+    target: { name: "test", value: "test" }
+  });
+  fireEvent.blur(getByTestId("input"));
+  fireEvent.click(getByTestId("submit"));
+  await waitForDomChange();
+  expect(queryByText("error")).toBeInTheDocument();
+  expect(queryByText("initialError")).toBeInTheDocument();
+});
+
 test("handles changes on multiselect without prop-types error", async () => {
   const { getByTestId, queryByText, getByText } = render(
     <Test>

--- a/src/form-item/index.tsx
+++ b/src/form-item/index.tsx
@@ -4,6 +4,7 @@ import { Form } from "antd";
 import { FormItemProps as $FormItemProps } from "antd/lib/form/FormItem";
 export type FormItemProps = {
   showValidateSuccess?: boolean;
+  showInitialErrorAfterTouched?: boolean;
   children: React.ReactNode;
 } & { name: string } & $FormItemProps &
   Pick<FieldConfig, "validate">;
@@ -11,30 +12,46 @@ export type FormItemProps = {
 export const FormItem = ({
   name,
   showValidateSuccess,
+  showInitialErrorAfterTouched = false,
   children,
   validate,
   ...restProps
 }: FormItemProps) => (
   <Field name={name} validate={validate}>
-    {({ form: { errors = {}, touched = {} } }: FieldProps) => {
+    {({
+      form: { errors = {}, touched = {}, initialErrors = {} }
+    }: FieldProps) => {
       const error = getIn(errors, name, undefined);
+      const initialError = getIn(initialErrors, name, undefined);
       let isTouched = getIn(touched, name, false) as boolean | boolean[];
       if (Array.isArray(isTouched)) {
         isTouched = isTouched.reduce((acc, value) => acc || value, false);
       }
       const hasError = error !== undefined && isTouched;
+      const hasInitialError = initialError !== undefined;
       const isValid = !error && isTouched;
       return (
         <Form.Item
           validateStatus={
-            hasError
+            hasError || (hasInitialError && !isTouched)
               ? "error"
               : isValid && showValidateSuccess
               ? "success"
               : undefined
           }
           hasFeedback={isValid}
-          help={(hasError && <li>{error}</li>) || (isValid && "")}
+          help={
+            (
+              <>
+                {hasError && <li>{error}</li>}
+                {hasInitialError &&
+                  (!isTouched || showInitialErrorAfterTouched) && (
+                    <li>{initialError}</li>
+                  )}
+              </>
+            ) ||
+            (isValid && "")
+          }
           {...restProps}
         >
           {children}


### PR DESCRIPTION
Fixes #110 

- Added support for `initialErrors` in FormItem
- introduced `showInitialErrorAfterTouched` in FormItem to display initial-error message after the field was touched
- wrote a few tests to validate functionality

