### PR TITLE
Adjusted Display of Errors in Form Item

### DIFF
--- a/src/form-item/index.tsx
+++ b/src/form-item/index.tsx
@@ -41,16 +41,14 @@ export const FormItem = ({
           }
           hasFeedback={isValid}
           help={
-            (
-              <>
-                {hasError && <li>{error}</li>}
-                {hasInitialError &&
-                  (!isTouched || showInitialErrorAfterTouched) && (
-                    <li>{initialError}</li>
-                  )}
-              </>
-            ) ||
-            (isValid && '')
+            <>
+              {hasError && <li>{error}</li>}
+              {hasInitialError &&
+                (!isTouched || showInitialErrorAfterTouched) && (
+                  <li>{initialError}</li>
+                )}
+              {isValid && ''}
+            </>
           }
           {...restProps}
         >


### PR DESCRIPTION
Adjusted  the display of initialErrors introduced in #110 .

The previous implementation always rendered a fragment. It could happen, that the fragment is empty and therefore we encountered some changes in the presentation of the component