### PR TITLE
Fixed unnecessary render of '.ant-form-explain' elements

### DIFF
--- a/src/form-item/index.test.tsx
+++ b/src/form-item/index.test.tsx
@@ -120,6 +120,24 @@ test('displayes initialError with error after touched when showInitialErrorAfter
   expect(queryByText('initialError')).toBeInTheDocument()
 })
 
+test('should not display help if no display is required', async () => {
+  const validate = () => 'error'
+  const { getByTestId } = render(
+    <Formik initialValues={{}} onSubmit={() => {}}>
+      <Form>
+        <FormItem name='test' validate={validate}>
+          <Input name='test' data-testid='input' />
+        </FormItem>
+        <SubmitButton data-testid='submit' />
+      </Form>
+    </Formik>,
+  )
+
+  const explainElement = getByTestId('input').parentElement!.nextSibling
+
+  expect(explainElement).toBeNull()
+})
+
 test('handles changes on multiselect without prop-types error', async () => {
   const { getByTestId, queryByText, getByText } = render(
     <Test>

--- a/src/form-item/index.tsx
+++ b/src/form-item/index.tsx
@@ -30,6 +30,10 @@ export const FormItem = ({
       const hasError = error !== undefined && isTouched
       const hasInitialError = initialError !== undefined
       const isValid = !error && isTouched
+      const showHelp =
+        hasError ||
+        (hasInitialError && (!isTouched || showInitialErrorAfterTouched))
+
       return (
         <Form.Item
           validateStatus={
@@ -41,14 +45,16 @@ export const FormItem = ({
           }
           hasFeedback={isValid}
           help={
-            <>
-              {hasError && <li>{error}</li>}
-              {hasInitialError &&
-                (!isTouched || showInitialErrorAfterTouched) && (
-                  <li>{initialError}</li>
-                )}
-              {isValid && ''}
-            </>
+            (showHelp && (
+              <>
+                {hasError && <li>{error}</li>}
+                {hasInitialError &&
+                  (!isTouched || showInitialErrorAfterTouched) && (
+                    <li>{initialError}</li>
+                  )}
+              </>
+            )) ||
+            (isValid && '')
           }
           {...restProps}
         >


### PR DESCRIPTION
Fixed problems introduced with #111 and not fixed with #116. 

In both cases an empty Fragment (<></>) was rendered if no cases are true. Antd interpretes this as an valid React Node and displays an empty row after every form item.