### PR TITLE
Added an optional callback `formatError` to allow custom error message handling

### DIFF
--- a/src/form-item/index.test.tsx
+++ b/src/form-item/index.test.tsx
@@ -193,6 +193,29 @@ test('displays validation result on nested input', async () => {
   expect(queryByText('error')).toBeInTheDocument()
 })
 
+test('allows errors to be customised with a callback', async () => {
+  const validate = () => 'error'
+  const formatError = (error: any) => `formatted-${error}`
+  const { getByTestId, queryByText } = render(
+    <Formik initialValues={{}} onSubmit={() => {}}>
+      <Form>
+        <FormItem name='test' validate={validate} formatError={formatError}>
+          <Input name='test' data-testid='input' />
+        </FormItem>
+        <SubmitButton data-testid='submit' />
+      </Form>
+    </Formik>,
+  )
+  expect(queryByText('formatted-error')).not.toBeInTheDocument()
+  fireEvent.change(getByTestId('input'), {
+    target: { name: 'test', value: 'test' },
+  })
+  fireEvent.blur(getByTestId('input'))
+  fireEvent.click(getByTestId('submit'))
+  await waitForDomChange()
+  expect(queryByText('formatted-error')).toBeInTheDocument()
+})
+
 test('displays validation success ', async () => {
   const validate = () => undefined
   const { getByTestId, queryByLabelText } = render(

--- a/src/form-item/index.tsx
+++ b/src/form-item/index.tsx
@@ -5,6 +5,7 @@ import { FormItemProps as $FormItemProps } from 'antd/lib/form/FormItem'
 export type FormItemProps = {
   showValidateSuccess?: boolean
   showInitialErrorAfterTouched?: boolean
+  formatError?: (error) => React.ReactNode
   children: React.ReactNode
 } & { name: string } & $FormItemProps &
   Pick<FieldConfig, 'validate'>
@@ -15,6 +16,7 @@ export const FormItem = ({
   showInitialErrorAfterTouched = false,
   children,
   validate,
+  formatError,
   ...restProps
 }: FormItemProps) => (
   <Field name={name} validate={validate}>
@@ -47,7 +49,9 @@ export const FormItem = ({
           help={
             showHelp && (
               <>
-                {hasError && <li>{error}</li>}
+                {hasError && (
+                  <li>{formatError ? formatError(error) : error}</li>
+                )}
                 {hasInitialError &&
                   (!isTouched || showInitialErrorAfterTouched) && (
                     <li>{initialError}</li>


### PR DESCRIPTION
Fixes https://github.com/jannikbuschke/formik-antd/issues/144