### PR TITLE
Pass the FormItem name onto the Formik FormItem to enable label accessibility

### DIFF
--- a/src/form-item/index.test.tsx
+++ b/src/form-item/index.test.tsx
@@ -213,3 +213,16 @@ test('displays validation success ', async () => {
   })
   expect(queryByLabelText('check-circle')).toBeInTheDocument()
 })
+
+test('labels link to the input element', async () => {
+  const { getByTestId, getByLabelText } = render(
+    <Formik initialValues={{}} onSubmit={() => {}}>
+      <Form>
+        <FormItem name='test' label='The label'>
+          <Input name='test' data-testid='input' />
+        </FormItem>
+      </Form>
+    </Formik>,
+  )
+  expect(getByLabelText('The label')).toEqual(getByTestId('input'))
+})

--- a/src/form-item/index.tsx
+++ b/src/form-item/index.tsx
@@ -55,6 +55,7 @@ export const FormItem = ({
               </>
             )
           }
+          name={name}
           {...restProps}
         >
           {children}


### PR DESCRIPTION
This is related to #25. This changes the formik-antd form items to match the behavior of antd form items, in that they do not require the `htmlFor` and `id` to be defined to get accessible label behavior. 

There are 4 tests failing on master, but I confirmed that this does not break any other tests.