### PR TITLE
Show form item feedback only if enabled

### DIFF
--- a/src/form-item/index.tsx
+++ b/src/form-item/index.tsx
@@ -15,6 +15,7 @@ export const FormItem = ({
   showInitialErrorAfterTouched = false,
   children,
   validate,
+  hasFeedback,
   ...restProps
 }: FormItemProps) => (
   <Field name={name} validate={validate}>
@@ -46,7 +47,7 @@ export const FormItem = ({
               ? 'success'
               : undefined
           }
-          hasFeedback={isValid}
+          hasFeedback={hasFeedback && isValid}
           help={
             showHelp && (
               <>


### PR DESCRIPTION
Currently, the feedback is automatically shown for all form items unless I explicitly turn it off 