### PR TITLE
Fix empty help message

### DIFF
--- a/src/form-item/index.tsx
+++ b/src/form-item/index.tsx
@@ -48,7 +48,7 @@ export const FormItem = ({
           }
           hasFeedback={isValid}
           help={
-            showHelp && (
+            showHelp ? (
               <>
                 {hasError && <li>{error}</li>}
                 {hasInitialError &&
@@ -56,7 +56,7 @@ export const FormItem = ({
                     <li>{initialError}</li>
                   )}
               </>
-            )
+            ) : null
           }
           name={name}
           {...restProps}


### PR DESCRIPTION
In the latest version of antd (4.18.5) in the Form.Item if `help` is set to `false` it will show as an empty div visible on the layout. PR fixes this small issue.