### PR TITLE
Add tests for select

### DIFF
--- a/src/select/index.test.tsx
+++ b/src/select/index.test.tsx
@@ -1,21 +1,15 @@
-import { Formik } from "formik"
-import React from "react"
+import { Formik } from 'formik'
+import React from 'react'
 import { Form } from '../form'
 import Select from './index'
 import '@testing-library/jest-dom/extend-expect'
 import { act } from 'react-dom/test-utils'
-import { screen, render, fireEvent } from '@testing-library/react'
-import { SelectProps } from 'antd/lib/select'
-
-/*
-jest.mock('antd/lib/select', () = (props: SelectProps<any>) => {
-	return <select></select>
-})
-*/
+import { fireEvent, render, screen } from '@testing-library/react'
 
 const TestSelect = () => {
 	return (
-		<Formik initialValues={{field: 0}} onSubmit={() => {}}>
+		<Formik initialValues={{ field: 0 }} onSubmit={() => {
+		}}>
 			<Form>
 				<Select name={'field'}>
 					<Select.Option value={0}>Zero</Select.Option>

--- a/src/select/index.test.tsx
+++ b/src/select/index.test.tsx
@@ -1,0 +1,48 @@
+import { Formik } from "formik"
+import React from "react"
+import { Form } from '../form'
+import Select from './index'
+import '@testing-library/jest-dom/extend-expect'
+import { act } from 'react-dom/test-utils'
+import { screen, render, fireEvent } from '@testing-library/react'
+import { SelectProps } from 'antd/lib/select'
+
+/*
+jest.mock('antd/lib/select', () = (props: SelectProps<any>) => {
+	return <select></select>
+})
+*/
+
+const TestSelect = () => {
+	return (
+		<Formik initialValues={{field: 0}} onSubmit={() => {}}>
+			<Form>
+				<Select name={'field'}>
+					<Select.Option value={0}>Zero</Select.Option>
+					<Select.Option value={1}>One</Select.Option>
+				</Select>
+			</Form>
+		</Formik>
+	)
+}
+
+test('renders select', async () => {
+	render(<TestSelect/>)
+	expect(screen.queryByRole('combobox')).toBeInTheDocument()
+})
+
+test('sets initial value', async () => {
+	const { queryByText } = render(<TestSelect/>)
+	expect(queryByText('Zero')).toBeInTheDocument()
+})
+
+test('changes selected upon clicking', async () => {
+	const { getByRole, queryByText, getByText, queryAllByText } = render(<TestSelect/>)
+	const selector = getByRole('combobox')
+	expect(queryByText('Zero')).toBeInTheDocument()
+	fireEvent.mouseDown(selector)
+	await act(async () => {
+		fireEvent.click(getByText('One'))
+	})
+	expect(queryAllByText('One').length).toBeGreaterThan(1)
+})

--- a/src/select/index.test.tsx
+++ b/src/select/index.test.tsx
@@ -4,7 +4,7 @@ import { Form } from '../form'
 import Select from './index'
 import '@testing-library/jest-dom/extend-expect'
 import { act } from 'react-dom/test-utils'
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, render } from '@testing-library/react'
 
 const TestSelect = () => {
 	return (
@@ -21,8 +21,8 @@ const TestSelect = () => {
 }
 
 test('renders select', async () => {
-	render(<TestSelect/>)
-	expect(screen.queryByRole('combobox')).toBeInTheDocument()
+	const { queryByRole } = render(<TestSelect />)
+	expect(queryByRole('combobox')).toBeInTheDocument()
 })
 
 test('sets initial value', async () => {
@@ -31,12 +31,12 @@ test('sets initial value', async () => {
 })
 
 test('changes selected upon clicking', async () => {
-	const { getByRole, queryByText, getByText, queryAllByText } = render(<TestSelect/>)
+	const { getByRole, queryByText, getByText, getAllByText } = render(<TestSelect/>)
 	const selector = getByRole('combobox')
 	expect(queryByText('Zero')).toBeInTheDocument()
 	fireEvent.mouseDown(selector)
 	await act(async () => {
 		fireEvent.click(getByText('One'))
 	})
-	expect(queryAllByText('One').length).toBeGreaterThan(1)
+	expect(getAllByText('One').length).toBeGreaterThan(1)
 })


### PR DESCRIPTION
1. Created a test to check if select is rendered
2. Created a test to see if the initial value is set on render. Did this using a check to see if the selected value is initially present or not. Couldn't use value since antd renders Select as input with combobox and doesn't update the value
3. Created a test to see if the value changes when the user clicks on a different option. Since `fireEvent.change` does not seem to work, I used `mouseDown` to first open the select and then `click` to select an option. antd renders the options as `span` so I was not able to use `option.selected`. Furthermore I used the check of `toBeGreaterThan` since I couldnt find a way to close the dropdown.

@jannikbuschke lmk what if you have any feedback or changes to be made

Referenced these links while coming up with the third test:

1. https://github.com/ant-design/ant-design/issues/22074#issuecomment-597061052
2. https://github.com/ant-design/ant-design/issues/23009