### PR TITLE
Fix Input.TextArea & Input.Password

### DIFF
--- a/components/src/input/index.tsx
+++ b/components/src/input/index.tsx
@@ -70,6 +70,7 @@ TypedInput.Password = React.forwardRef(
       fast,
       onChange: $onChange,
       onBlur: $onBlur,
+      value,
       ...restProps
     }: PasswordProps,
     ref: React.Ref<InputRef>,
@@ -104,6 +105,7 @@ TypedInput.TextArea = React.forwardRef(
       fast,
       onChange: $onChange,
       onBlur: $onBlur,
+      value,
       ...restProps
     }: TextAreaProps,
     ref: React.Ref<TextAreaRef>,


### PR DESCRIPTION
Just extract the value property in these two components so it doesn't erase the one from formik through the `restProps`.